### PR TITLE
Fix super weird bug where veracross returns a slightly different calendar

### DIFF
--- a/src/schedule/veracross/veracrossICalUtils.ts
+++ b/src/schedule/veracross/veracrossICalUtils.ts
@@ -5,7 +5,7 @@ export class VeracrossICalUtils {
     private static scheduleCalendarTimeZone = 'America/Los_Angeles'; // the ical calendar parsing compensates for time zones, which is not what we want
 
     static getVeracrossCalendarFromUUID = (calendarUUID: string): Promise<any> =>
-        VeracrossICalUtils.corsGetPromise(`http://api.veracross.com/catlin/subscribe/${calendarUUID}.ics`).then(
+        VeracrossICalUtils.corsGetPromise(`http://api.veracross.com/catlin/subscribe/${calendarUUID}.ics?uid`).then(
             icsFile => {
                 // @ts-ignore
                 return ICAL.parse(icsFile)[2];


### PR DESCRIPTION
…ndar if "?uid" is at the end of the url